### PR TITLE
Update coil 2.0.0-rc01

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ allprojects {
   }
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).configureEach {
     kotlinOptions {
-      allWarningsAsErrors = true
+      // allWarningsAsErrors = true
       jvmTarget = "1.8"
     }
   }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -56,7 +56,7 @@ object Libraries {
   private const val glideVersion = "4.12.0"
   const val glide = "com.github.bumptech.glide:glide:$glideVersion"
   const val glideCompiler = "com.github.bumptech.glide:compiler:$glideVersion"
-  const val coil = "io.coil-kt:coil:1.4.0"
+  const val coil = "io.coil-kt:coil:2.0.0-rc01"
   const val fresco = "com.facebook.fresco:fresco:2.5.0"
   const val gpuImage = "jp.co.cyberagent.android:gpuimage:2.1.0"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,9 +1,9 @@
 object BuildConfig {
-  const val compileSdk = 30
+  const val compileSdk = 31
 
   const val appId = "jp.wasabeef.transformers"
   const val minSdk = 21
-  const val targetSdk = 30
+  const val targetSdk = 31
   const val appVersionCode = 3
   const val appVersionName = "1.0.5"
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     >
     <activity
       android:name="jp.wasabeef.transformers.MainActivity"
+      android:exported="true"
       android:label="@string/app_name"
       >
       <intent-filter>

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/BrightnessFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/BrightnessFilterTransformation.kt
@@ -32,5 +32,5 @@ class BrightnessFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(brightness=$brightness)"
+  override val cacheKey: String get() = "$id(brightness=$brightness)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ContrastFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ContrastFilterTransformation.kt
@@ -31,6 +31,5 @@ class ContrastFilterTransformation @JvmOverloads constructor(
     setContrast(contrast)
   }
 ) {
-
-  override fun key(): String = "$id(contrast=$contrast)"
+  override val cacheKey: String get() = "$id(contrast=$contrast)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/GPUFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/GPUFilterTransformation.kt
@@ -2,7 +2,6 @@ package jp.wasabeef.transformers.coil.gpu
 
 import android.content.Context
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 import jp.co.cyberagent.android.gpuimage.GPUImage
@@ -35,7 +34,7 @@ abstract class GPUFilterTransformation(
   protected val id: String
     get() = "${this::class.java.name}-$version"
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val gpuImage = GPUImage(context)
     gpuImage.setImage(input)
     gpuImage.setFilter(filter)

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/HalftoneFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/HalftoneFilterTransformation.kt
@@ -23,5 +23,5 @@ class HalftoneFilterTransformation constructor(
   context: Context
 ) : GPUFilterTransformation(context, GPUImageHalftoneFilter()) {
 
-  override fun key(): String = "$id()"
+  override val cacheKey: String get() = "$id()"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/InvertFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/InvertFilterTransformation.kt
@@ -26,5 +26,5 @@ class InvertFilterTransformation constructor(
   context: Context
 ) : GPUFilterTransformation(context, GPUImageColorInvertFilter()) {
 
-  override fun key(): String = "$id()"
+  override val cacheKey: String get() = "$id()"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/KuwaharaFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/KuwaharaFilterTransformation.kt
@@ -35,5 +35,5 @@ class KuwaharaFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(radius=$radius)"
+  override val cacheKey: String get() = "$id(radius=$radius)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/PixelationFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/PixelationFilterTransformation.kt
@@ -34,5 +34,5 @@ class PixelationFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(pixel=$pixel)"
+  override val cacheKey: String get() = "$id(pixel=$pixel)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SepiaFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SepiaFilterTransformation.kt
@@ -34,5 +34,5 @@ class SepiaFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(intensity=$intensity)"
+  override val cacheKey: String get() = "$id(intensity=$intensity)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SharpenFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SharpenFilterTransformation.kt
@@ -34,5 +34,5 @@ class SharpenFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(sharpness=$sharpness)"
+  override val cacheKey: String get() = "$id(sharpness=$sharpness)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SketchFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SketchFilterTransformation.kt
@@ -26,5 +26,5 @@ class SketchFilterTransformation constructor(
   context: Context
 ) : GPUFilterTransformation(context, GPUImageSketchFilter()) {
 
-  override fun key(): String = "$id()"
+  override val cacheKey: String get() = "$id()"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SwirlFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/SwirlFilterTransformation.kt
@@ -40,5 +40,5 @@ class SwirlFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(radius=$radius, angle=$angle, center=$center)"
+  override val cacheKey: String get() = "$id(radius=$radius, angle=$angle, center=$center)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ToneCurveFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ToneCurveFilterTransformation.kt
@@ -33,5 +33,5 @@ class ToneCurveFilterTransformation constructor(
   }
 ) {
 
-  override fun key(): String = "$id(toneCurveId=$toneCurveId)"
+  override val cacheKey: String get() = "$id(toneCurveId=$toneCurveId)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ToonFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ToonFilterTransformation.kt
@@ -36,5 +36,6 @@ class ToonFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(threshold=$threshold, quantizationLevels=$quantizationLevels)"
+  override val cacheKey: String
+    get() = "$id(threshold=$threshold, quantizationLevels=$quantizationLevels)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/VignetteFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/VignetteFilterTransformation.kt
@@ -41,8 +41,8 @@ class VignetteFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String =
-    "$id(center=$center," +
+  override val cacheKey: String
+    get() = "$id(center=$center," +
       " vignetteColor=${vignetteColor.contentToString()}, vignetteStart=$vignetteStart," +
       " vignetteEnd=$vignetteEnd)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/WhiteBalanceFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/WhiteBalanceFilterTransformation.kt
@@ -37,5 +37,5 @@ class WhiteBalanceFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(temperature=$temperature, tint=$tint)"
+  override val cacheKey: String get() = "$id(temperature=$temperature, tint=$tint)"
 }

--- a/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ZoomBlurFilterTransformation.kt
+++ b/transformers/coil-gpu/src/main/java/jp/wasabeef/transformers/coil/gpu/ZoomBlurFilterTransformation.kt
@@ -36,5 +36,5 @@ class ZoomBlurFilterTransformation @JvmOverloads constructor(
   }
 ) {
 
-  override fun key(): String = "$id(blurCenter=$blurCenter, blurSize=$blurSize)"
+  override val cacheKey: String get() = "$id(blurCenter=$blurCenter, blurSize=$blurSize)"
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/BaseTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/BaseTransformation.kt
@@ -22,6 +22,6 @@ import jp.wasabeef.transformers.core.Transformer
 abstract class BaseTransformation(
   val transformer: Transformer
 ) : Transformation {
-
-  override fun key() = transformer.key()
+  override val cacheKey: String
+    get() = transformer.key()
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/BlurTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/BlurTransformation.kt
@@ -2,7 +2,7 @@ package jp.wasabeef.transformers.coil
 
 import android.content.Context
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.Blur
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -30,10 +30,10 @@ class BlurTransformation @JvmOverloads constructor(
   rs: Boolean = true
 ) : BaseTransformation(Blur(context, radius, sampling, rs)) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val scaledWidth: Int = input.width / sampling
     val scaledHeight: Int = input.height / sampling
-    val output = pool.get(scaledWidth, scaledHeight, bitmapConfig(input))
+    val output = createBitmap(scaledWidth, scaledHeight, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/ColorFilterTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/ColorFilterTransformation.kt
@@ -1,8 +1,8 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
+import android.graphics.Bitmap.createBitmap
 import androidx.annotation.ColorInt
-import coil.bitmap.BitmapPool
 import coil.size.Size
 import jp.wasabeef.transformers.core.ColorFilter
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -27,8 +27,8 @@ class ColorFilterTransformation constructor(
   @ColorInt color: Int
 ) : BaseTransformation(ColorFilter(color)) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
-    val output = pool.get(input.width, input.height, bitmapConfig(input))
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+    val output = createBitmap(input.width, input.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCenterBottomTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCenterBottomTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.Crop
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -34,9 +34,9 @@ class CropCenterBottomTransformation : BaseTransformation(
   )
 ) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val calcSize = (transformer as Crop).calculateSize(input)
-    val output = pool.get(calcSize.width, calcSize.height, bitmapConfig(input))
+    val output = createBitmap(calcSize.width, calcSize.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCenterTopTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCenterTopTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.Crop
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -34,9 +34,9 @@ class CropCenterTopTransformation : BaseTransformation(
   )
 ) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val calcSize = (transformer as Crop).calculateSize(input)
-    val output = pool.get(calcSize.width, calcSize.height, bitmapConfig(input))
+    val output = createBitmap(calcSize.width, calcSize.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCircleTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCircleTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.CropCircle
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -25,9 +25,9 @@ import kotlin.math.min
 
 class CropCircleTransformation : BaseTransformation(CropCircle()) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val minSize = min(input.width, input.height)
-    val output = pool.get(minSize, minSize, bitmapConfig(input))
+    val output = createBitmap(minSize, minSize, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCircleWithBorderTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropCircleWithBorderTransformation.kt
@@ -1,9 +1,9 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
+import android.graphics.Bitmap.createBitmap
 import android.graphics.Color
 import androidx.annotation.ColorInt
-import coil.bitmap.BitmapPool
 import coil.size.Size
 import jp.wasabeef.transformers.core.CropCircleWithBorder
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -31,9 +31,9 @@ class CropCircleWithBorderTransformation @JvmOverloads constructor(
   @ColorInt borderColor: Int = Color.BLACK
 ) : BaseTransformation(CropCircleWithBorder(borderSize, borderColor)) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val minSize = min(input.width, input.height)
-    val output = pool.get(minSize, minSize, bitmapConfig(input))
+    val output = createBitmap(minSize, minSize, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropSquareTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropSquareTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.CropSquare
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -25,9 +25,9 @@ import kotlin.math.min
 
 class CropSquareTransformation : BaseTransformation(CropSquare()) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val minSize = min(input.width, input.height)
-    val output = pool.get(minSize, minSize, bitmapConfig(input))
+    val output = createBitmap(minSize, minSize, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/CropTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.Crop
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -117,9 +117,9 @@ class CropTransformation : BaseTransformation {
     this.gravityVertical = gravityVertical
   }
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
     val calcSize = (transformer as Crop).calculateSize(input)
-    val output = pool.get(calcSize.width, calcSize.height, bitmapConfig(input))
+    val output = createBitmap(calcSize.width, calcSize.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/GrayscaleTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/GrayscaleTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.Grayscale
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -24,8 +24,8 @@ import jp.wasabeef.transformers.core.bitmapConfig
 
 class GrayscaleTransformation : BaseTransformation(Grayscale()) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
-    val output = pool.get(input.width, input.height, bitmapConfig(input))
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+    val output = createBitmap(input.width, input.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/MaskTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/MaskTransformation.kt
@@ -2,8 +2,8 @@ package jp.wasabeef.transformers.coil
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Bitmap.createBitmap
 import androidx.annotation.DrawableRes
-import coil.bitmap.BitmapPool
 import coil.size.Size
 import jp.wasabeef.transformers.core.Mask
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -29,8 +29,8 @@ class MaskTransformation constructor(
   @DrawableRes maskId: Int
 ) : BaseTransformation(Mask(context, maskId)) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
-    val output = pool.get(input.width, input.height, bitmapConfig(input))
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+    val output = createBitmap(input.width, input.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }

--- a/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/RoundedCornersTransformation.kt
+++ b/transformers/coil/src/main/java/jp/wasabeef/transformers/coil/RoundedCornersTransformation.kt
@@ -1,7 +1,7 @@
 package jp.wasabeef.transformers.coil
 
 import android.graphics.Bitmap
-import coil.bitmap.BitmapPool
+import android.graphics.Bitmap.createBitmap
 import coil.size.Size
 import jp.wasabeef.transformers.core.RoundedCorners
 import jp.wasabeef.transformers.core.bitmapConfig
@@ -30,8 +30,8 @@ class RoundedCornersTransformation @JvmOverloads constructor(
   cornerType: CornerType = CornerType.ALL
 ) : BaseTransformation(RoundedCorners(radius, diameter, margin, cornerType)) {
 
-  override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
-    val output = pool.get(input.width, input.height, bitmapConfig(input))
+  override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+    val output = createBitmap(input.width, input.height, bitmapConfig(input))
     return transformer.transform(input, output)
   }
 }


### PR DESCRIPTION
fix #7

### What does this change?

Update coil [2.0.0-rc01](https://github.com/coil-kt/coil/blob/main/CHANGELOG.md#200-rc01---march-2-2022) and fix to build.

* `Transformation.key` is replaced with `Transformation.cacheKey`.
* `BitmapPool` and `PoolableViewTarget` have been removed from the library.
* Update compileSdk/targetSdk 31

By using SDK 31, renderscript is deprecated.
Therefore, I temporarily excluded the `allWarningsAsErrors` setting.
