### PR TITLE
chore: bump up to 1.0.6

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="USE_SAME_INDENTS" value="true" />
-    <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true" />
     <option name="OTHER_INDENT_OPTIONS">
       <value>
         <option name="INDENT_SIZE" value="2" />
@@ -9,12 +7,12 @@
         <option name="TAB_SIZE" value="2" />
       </value>
     </option>
-    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
-    <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="KEEP_LINE_BREAKS" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
@@ -94,9 +92,6 @@
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <ADDITIONAL_INDENT_OPTIONS fileType="php">
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Version 1.0.6 *(2022-03-10)*
+----------------------------
+
+Updates:
+- Coil to 2.0.0-rc01
+- compileSdkVersion to 31 
+- targetSdkVersion to 31
+
 Version 1.0.5 *(2021-10-08)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ repositories {
 #### For [Coil] <a href="https://github.com/coil-kt/coil"><img src="https://github.com/wasabeef/transformers/raw/main/art/coil.png" width="12px"/></a>
 ```gradle
 dependencies {
-  implementation 'jp.wasabeef.transformers:coil:1.0.5'
+  implementation 'jp.wasabeef.transformers:coil:1.0.6'
   // Use the GPU Filters 
-  implementation 'jp.wasabeef.transformers:coil-gpu:1.0.5'
+  implementation 'jp.wasabeef.transformers:coil-gpu:1.0.6'
 }
 ```
 ```kotlin
@@ -81,9 +81,9 @@ imageView.load(IMAGE_URL) {
 #### For [Glide] <a href="https://github.com/bumptech/glide"><img src="https://github.com/wasabeef/transformers/raw/main/art/glide.png" width="12px"/></a>
 ```gradle
 dependencies {
-  implementation 'jp.wasabeef.transformers:glide:1.0.5'
+  implementation 'jp.wasabeef.transformers:glide:1.0.6'
   // Use the GPU Filters 
-  implementation 'jp.wasabeef.transformers:glide-gpu:1.0.5'
+  implementation 'jp.wasabeef.transformers:glide-gpu:1.0.6'
 }
 ```
 ```kotlin
@@ -102,9 +102,9 @@ Glide.with(context)
 #### For [Picasso] <a href="https://github.com/square/picasso"><img src="https://github.com/wasabeef/transformers/raw/main/art/picasso.jpg" width="12px"/></a>
 ```gradle
 dependencies {
-  implementation 'jp.wasabeef.transformers:picasso:1.0.5'
+  implementation 'jp.wasabeef.transformers:picasso:1.0.6'
   // Use the GPU Filters 
-  implementation 'jp.wasabeef.transformers:picasso-gpu:1.0.5'
+  implementation 'jp.wasabeef.transformers:picasso-gpu:1.0.6'
 }
 ```
 ```kotlin
@@ -122,9 +122,9 @@ Picasso.get()
 #### For [Fresco] <a href="https://github.com/facebook/fresco"><img src="https://github.com/wasabeef/transformers/raw/main/art/fresco.png" width="12px"/></a>
 ```gradle
 dependencies {
-  implementation 'jp.wasabeef.transformers:fresco:1.0.5'
+  implementation 'jp.wasabeef.transformers:fresco:1.0.6'
   // Use the GPU Filters 
-  implementation 'jp.wasabeef.transformers:fresco-gpu:1.0.5'
+  implementation 'jp.wasabeef.transformers:fresco-gpu:1.0.6'
 }
 ```
 ```kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
   }
 
   dependencies {
-    classpath("com.android.tools.build:gradle:7.0.2")
+    classpath("com.android.tools.build:gradle:7.1.2")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Libraries.kotlinVersion}")
   }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,8 +4,8 @@ object BuildConfig {
   const val appId = "jp.wasabeef.transformers"
   const val minSdk = 21
   const val targetSdk = 31
-  const val appVersionCode = 3
-  const val appVersionName = "1.0.5"
+  const val appVersionCode = 4
+  const val appVersionName = "1.0.6"
 
   const val testRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
@@ -24,7 +24,7 @@ object Projects {
   const val frescoGpu = ":transformers:fresco-gpu"
 
   object FromRepo {
-    const val transformersVersion = "1.0.5"
+    const val transformersVersion = "1.0.6"
     const val glide = "jp.wasabeef.transformers:glide:$transformersVersion"
     const val glideGpu = "jp.wasabeef.transformers:glide-gpu:$transformersVersion"
     const val picasso = "jp.wasabeef.transformers:picasso:$transformersVersion"


### PR DESCRIPTION
### What does this change?

Updates:
- Coil to 2.0.0-rc01
- compileSdkVersion to 31 
- targetSdkVersion to 31